### PR TITLE
[sourcegraph-bot] Fixed docker image(s) with vulnerabilities.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.18-alpine3.11 as builder
+FROM 528451384384.dkr.ecr.us-west-2.amazonaws.com/segment-node:17.2 as builder
 RUN apk add --update curl ca-certificates make git gcc g++ python
 WORKDIR /app
 COPY ./ /app
@@ -7,7 +7,7 @@ COPY . .
 # Rebuild any native bindings that were copied over from CircleCI
 RUN npm rebuild
 # Use a multi stage build so that the packages required for compiling native bindings aren't in the final image
-FROM node:10.18-alpine3.10
+FROM 528451384384.dkr.ecr.us-west-2.amazonaws.com/segment-node:17.2
 WORKDIR /app
 # Output Node version info so we know exactly what version was used
 RUN npm version


### PR DESCRIPTION
1 . Snyk has detected vulnerabilities in the docker image(s)   node:10.18-alpine3.10
 used in this repository. Please refer to the [docker security metrics](https://app.snowflake.com/us-west-2/segmentdataeng/w1iVJjEKKQ7j) to know the exact number and severity of the vulnerabilities .

2 . We recommend using the following image and your Dockerfile has been updated to reflect this.
- [528451384384.dkr.ecr.us-west-2.amazonaws.com/segment-node:17.2](https://github.com/segmentio/images/blob/master/segment/node/Dockerfile.17.2)


3 . To know more about the best practices around building docker images at Segment, please refer to the following documents:-
- [Docker Compendium](https://paper.dropbox.com/doc/Docker-compendium--BWPzI7y45KYLoS~vEAht~gcLAg-yTYmcGdMDbPi4iSFLDiQc#:h2=Use-explicitly-versioned-docke)
- [Docker Build Processes](https://paper.dropbox.com/doc/Proposal-Docker-Build-Processes-and-Versioning-changes--BWNllnN_kEd5lHQ~C3V_xPR4Ag-i4taZtwCAaGOz2seHRf0x#:uid=590347575445228750534908&h2=Proposal---Move-to-explicitly-)

[_Created by Sourcegraph batch change `abhinav.ittekot/docker-vulnerability-remediation-node-Images`._](https://sourcegraph.segment.com/users/abhinav.ittekot/batch-changes/docker-vulnerability-remediation-node-Images)